### PR TITLE
Fix invalid default option for coordinate remapping 

### DIFF
--- a/mastu_diagnostics.py
+++ b/mastu_diagnostics.py
@@ -76,7 +76,8 @@ def get_data_mastu(
         'Detect zero error' : True,
         'atol' : 1e-12,
         'rtol' : 1e-9,
-        'Coordinate remapping' : {'names': {}, 'units': {}},
+        # This will be evaluated by ast.literal_eval:
+        'Coordinate remapping' : "{'names': {}, 'units': {}}",
     }
 
     _options = flap.config.merge_options(


### PR DESCRIPTION
Added missing quotes for the default option as it will be parsed by `ast.literal_eval`. The malformed default option made it impossible to use the diagnostic import without coordinate remapping.