### PR TITLE
Added option for automatic sharp peak removal + small improvements

### DIFF
--- a/mast_bes.py
+++ b/mast_bes.py
@@ -86,10 +86,18 @@ def get_data_mast_bes(exp_id=None, data_name=None, no_data=False, options=None, 
                     not enabled.
         'Server' (default=None): str, Server to download from.
         'Server port' (default=None): str, Server port to use.
+        'Offset timerange': (default=[-0.1,-0.01]):
+            - list of two values: [start, end]. The time range used for offset calculation.
+            - None: No offset calculation.
         'Resample': Resample to this frequency [Hz]. Only frequencies below the sampling frequency can be used.
                     The frequency will be rounded to the integer times the sampling frequency.
                     Data will be averaged in blocks and the variance in blocks will be added as error.
-        'Test measurement':
+        'Remove sharp peaks': (default=False):
+            - True: Remove sharp peaks from the data automatically during import
+              using the `remove_sharp_peaks` function in FLAP. Options for
+              `remove_sharp_peaks` must be set in the [Denoising] section.
+            - False: Do nothing.
+        'Test measurement': bool, default=False
 
     Return value
     ------------
@@ -109,6 +117,7 @@ def get_data_mast_bes(exp_id=None, data_name=None, no_data=False, options=None, 
                        'Scaling':'Digit',
                        'Offset timerange': [-0.1,-0.01],
                        'Resample' : None,
+                       'Remove sharp peaks': False,
                        'Test measurement': False
                        }
     _options = flap.config.merge_options(default_options,options,data_source='MAST_BES')
@@ -629,6 +638,11 @@ def get_data_mast_bes(exp_id=None, data_name=None, no_data=False, options=None, 
         data_title += ", " + chname_proc[0]
     d = flap.DataObject(data_array=data_arr,error=error_arr,data_unit=data_unit,
                         coordinates=coord, exp_id=exp_id,data_title=data_title,info=camera_info)
+
+    if _options['Remove sharp peaks']:
+        print('Performing sharp peak removal...')
+        d = d.remove_sharp_peaks()
+
     return d
 
 

--- a/mastu_diagnostics.py
+++ b/mastu_diagnostics.py
@@ -117,6 +117,10 @@ def get_data_mastu(
     # https://stackoverflow.com/a/71199182
     file_name = re.sub(r"[/\\?%*:|\"<>\x7F\x00-\x1F]", "-", data_name) + '.hdf5'
 
+    # Remove leading '-' if present to make matters easier
+    if file_name[0] == '-':
+        file_name = file_name[1:]
+
     if cache_used:
         shotstring = str(exp_id).zfill(6)
         datafile = os.path.join(datapath, shotstring, file_name)
@@ -152,6 +156,7 @@ def get_data_mastu(
                 print(f"Using datafile '{datafile}'.")
 
     if download_file:
+        print("Downloading via pyUDA...")
         default_pyuda_options = {
             'Server': None,
             'Server port': None,
@@ -163,7 +168,6 @@ def get_data_mastu(
             data_source=data_source,
             section='pyUDA')
         
-        print("Downloading via pyUDA...")
         try:
             if pyuda_options['Server port'] is None:
                 raise ValueError("Server port is None.")


### PR DESCRIPTION
Added option for automatic sharp peak removal based on the new `remove_sharp_peaks` method in `flap.denoising` (see pull request #104 in flap). Corresponding option in the configuration is 'Remove sharp peaks'.

Additionally, the documentation has also been updated to include the existing, but undocumented feature 'Offset timerange', and some minor improvements were made to the caching logic.