### PR TITLE
Automatic and manual intensity calibration

### DIFF
--- a/intensity_calibration.py
+++ b/intensity_calibration.py
@@ -1,0 +1,503 @@
+from operator import itemgetter
+import os
+
+import h5py
+import numpy as np
+from scipy.spatial import KDTree
+
+import flap
+
+def file_name_from_shot_number(shot_number):
+    shotstring = str(shot_number).zfill(6)
+    return f'xbt{shotstring}.nc'
+
+class CalibrationReference:
+    """Object representing an intensity calibration refererence.
+        
+    The representation is aimed at providing a possibility to compare the
+    circumstances of a measurement to other measurements, which can be used as
+    calibration reference measurements.  Automatic construction from a MAST-U
+    shot is recommended via the `.from_MAST_U_shot()` class method. Saving and
+    loading to and from a JSON file is also supported via the appropriate
+    methods.
+
+    Parameters
+    ----------
+    coordinates : dict
+        Calibration coordinates. The keys are the coordinate names, the
+        values are the dimensionful coordinate values.
+    info : dict, optional (default=None)
+        Dictionary containing additonal non-coordinate information and metadata.
+    calibration_multiplier_matrix : list of list of float, optional (default=None)
+        Calibration multiplier matrix. A BES measurement can be multiplied
+        by this matrix to perform the intensity calibration along the
+        channels.
+    calibration_source : dict, optional (default=None)
+        Dictionary containing information about the source of information
+        used to create the calibration multiplier matrix.
+    """
+    def __init__(self,
+                 coordinates,
+                 info=None,
+                 calibration_multiplier_matrix=None,
+                 calibration_source=None,
+                ):
+        if not isinstance(coordinates, dict):
+            raise ValueError("Argument 'coordinates' must be a dictionary.")
+            
+        if ((info is not None) and (not isinstance(info, dict))):
+            raise ValueError("Argument 'info' must be None or a dictionary.")
+
+        self.coordinates_dimful = coordinates
+        self.info = info
+
+        # These are only used if this will be used as a reference measurement
+        self.calibration_multiplier_matrix = calibration_multiplier_matrix
+        self.calibration_source = calibration_source
+
+    def __repr__(self):
+        return f"CalibrationCoordinates(coordinates={repr(self.coordinates_dimful)}, info={repr(self.info)}, calibration_multiplier_matrix={repr(self.calibration_multiplier_matrix)}, calibration_source={repr(self.calibration_source)}"
+
+    def to_json(self):
+        import json
+        return json.dumps(self, default=lambda o: o.__dict__, sort_keys=True, indent=4)
+
+    @classmethod
+    def from_json(cls, json_string):
+        """Construct a CalibrationReference object from a JSON string.
+
+        Parameters
+        ----------
+        json_string : str
+            JSON representation of the object. (Usually have been created via
+            the `.to_json()` method.)
+
+        Returns
+        -------
+        CalibratioReference
+            The resulting CalibrationReference object.
+        """
+        import json
+        attrs = json.loads(json_string)
+        if not isinstance(attrs, dict):
+            raise ValueError('Invalid JSON: must parse to a dict.')
+
+        if 'info' not in attrs.keys():
+            raise ValueError("Invalid JSON: must contain an 'info' key.")
+        
+        if 'coordinates_dimful' not in attrs.keys():
+            raise ValueError("Invalid JSON: must contain a 'coordinates_dimful' key.")
+
+        if 'calibration_multiplier_matrix' in attrs.keys():
+            calibration_multiplier_matrix = attrs['calibration_multiplier_matrix']
+        else:
+            calibration_multiplier_matrix = None
+            
+        if 'calibration_source' in attrs.keys():
+            calibration_source = attrs['calibration_source']
+        else:
+            calibration_source = None
+        
+        return cls(
+            coordinates=attrs['coordinates_dimful'],
+            info=attrs['info'],
+            calibration_multiplier_matrix=calibration_multiplier_matrix,
+            calibration_source=calibration_source,
+        )
+
+    @classmethod
+    def from_MAST_U_shot(cls,
+                         shotnumber,
+                         beam_voltage_threshold_SI=1.0,
+                         flap_getdata_options_voltage=None,
+        ):
+        """Automatically create a CalibrationReference object from a MAST-U shot.
+
+        Calibration coordinates are:
+
+        - APDCAM view radius [1 coordinate]:
+
+          - 'APDCam_viewRadius' (float)
+
+        - APDCAM set bias voltage [2 coordinates, only first two are set on MAST-U APDCam]:
+
+          - 'APDCam_biasSet0' (float)
+
+          - 'APDCam_biasSet1' (float)
+
+        - Filter temperature reading [1 coordinate]
+
+          - 'filter_temperature_read' (int)
+
+        - SS beam voltage (99% percentile of signal values over voltage
+          threshold) [1 coordinate]
+
+          - 'SS_voltage_99' (float, rounded to a single digit)
+
+        Parameters
+        ----------
+        shotnumber : int
+            The MAST-U shot number to use.
+        beam_voltage_threshold_SI : float, optional (default=1.0)
+            Voltage threshold over which the beam is considered to be 'on'. The
+            values above this are used to calculate the reference (or 'target')
+            SS beam voltage
+        flap_getdata_options_voltage : dict, optional (default=None)
+            A dictionary of options to be passed on to the flap.get_data() call
+            when loading the SS voltage measurement data.
+
+        Returns
+        -------
+        CalibrationReference
+            The CalibrationReference object containing the calibration
+            coordinates of the given shot. The calibration multiplier matrix is
+            not created automatically, but can be created separately, via the
+            appropriate method.
+        """
+        if flap_getdata_options_voltage is None:
+            flap_getdata_options_voltage = {}
+
+        try:
+            d_SS_VOLTAGE = flap.get_data('MAST-U', shotnumber, name='ANB/SS/VOLTAGE', options=flap_getdata_options_voltage)
+        except Exception as e:
+            raise ValueError(f'Shot {shotnumber} has no SS beam voltage data.') from e
+        
+        SS_VOLTAGE_99 = np.percentile(d_SS_VOLTAGE.data[d_SS_VOLTAGE.data > beam_voltage_threshold_SI], 99)
+        
+        shotstring = str(shotnumber).zfill(6)
+        
+        try:
+            shots_folder_bes = flap.config.interpret_config_value(flap.config.get('Module MAST_BES', 'Cache directory'))
+        except ValueError:
+            shots_folder_bes = None
+            
+        if shots_folder_bes is not None:
+            nc_file = os.path.join(shots_folder_bes, shotstring, file_name_from_shot_number(shotnumber))
+                               
+            with h5py.File(nc_file) as f:
+                apdcam_viewRadius = f['devices']['d3_APDcamera10G'].attrs['viewRadius']
+                apdcam_biasSet = f['devices']['d3_APDcamera10G'].attrs['biasSet']
+                filter_temperature_read = f['devices']['d8_filterheater'].attrs['temperature_read']
+        else:
+            raise NotImplementedError('Only loading from cache directory directly is supported.')
+        
+        coordinates_dimful = {
+            'APDCam_viewRadius': float(apdcam_viewRadius[0]),
+            'APDCam_biasSet0': float(apdcam_biasSet[0]),
+            'APDCam_biasSet1': float(apdcam_biasSet[1]),
+            'filter_temperature_read' : int(filter_temperature_read[0]),
+            'SS_voltage_99' : np.round(SS_VOLTAGE_99, decimals=1),
+        }
+    
+        return cls(
+            coordinates=coordinates_dimful,
+            info={'shot' : shotnumber, 'beam_voltage_threshold_SI' : beam_voltage_threshold_SI},
+            calibration_multiplier_matrix=None,  # Created in a separate method, only if needed
+            calibration_source=None,  # Created in a separate method, only if needed
+        )
+
+    def create_calibration_matrix(self,
+                                  time_interval_s,
+                                  method='mean',
+        ):
+        """Create a calibration multiplier matrix from a measurement, associated
+        to the CalibrationReference object.
+
+        A calibration matrix is used to compensate for the relative differences
+        of measured voltage levels corresponding to the same intensity on
+        different BES channels.
+        
+        The calibration matrix is created by calculating an aggregate (e.g.
+        mean) value in the provided time interval for each channel separately, then
+        calculating a multiplier for each channel that brings the different
+        voltages to the same level along all channels, which is the maximum
+        value measured during the interval along all channels. Naturally, this
+        method assumes that the actual intensity is identical along the
+        channels.
+
+        ----------
+        time_interval_s : list of float
+            Time interval from the measurement to be used as the basis of
+            calibration.
+        method : str, optional (default='mean')
+            Aggregation method to be used. Currently only method 'mean' is
+            supported.
+        """
+
+        shot = self.info['shot']
+        d_reference = flap.get_data(
+            'MAST_BES',
+            exp_id=shot,
+            name='BES-*-*',
+            coordinates={'Time' : time_interval_s},
+            options={'Calibrate intensity' : False},  # !!!
+        )
+
+        channel_map = d_reference.coordinate('ADC Channel')[0][0]
+
+        self.calibration_source = {
+            'time_interval_s' : list(time_interval_s),
+            'channel_map' : channel_map.tolist(),
+        }
+
+        if method == 'mean':
+            cal_data = d_reference.slice_data(summing={'Sample' : 'Mean'})
+        else:
+            raise ValueError("Only method 'mean' is supported currently.")
+
+        # Convert ndarray to list so it can be serialized later
+        self.calibration_multiplier_matrix = (np.max(cal_data.data) / cal_data.data).tolist()
+    
+class CalibrationDatabase():
+    """Calibration database for storing CalibrationReference objects and finding
+    the closest match.
+
+    The database of CalibrationReference object can be queried, via
+    `find_nearest_match()`, by matching along the calibration coordinates. Two
+    types of calibration coordinates are considered: exactly and closely matched
+    coordinates. These are to be provided separately and explicitly. Only these
+    coordinates are considered in a query.
+
+    Parameters
+    ----------
+    calibration_reference_list : list of CalibrationReference
+        The list of CalibrationReference objects to query against. A set of K-d
+        trees are created for each unique combination of exactly matched
+        coordinates for quick lookup.
+    closely_matched_coordinates : list of str
+        List of coordinates to be matched not exactly but only in an Euclidean
+        nearest neighbor sense. The nearest neighbor calculations are performed
+        in a dimensionless space where all the coordinates have been normalized
+        to the 0-1 range by the observed minima and maxima, to avoid improper
+        matched that would occur due to different magnitude of the coordinates.
+    exactly_matched_coordinates : list of str, optional (default=None)
+        List of coordinates to be matched exactly. A nearest neighbor lookup is
+        only performed if the database contains at least one
+        CalibrationReference object for which all exactly matched coordinates
+        are identical with those of the query.
+    exactly_matched_round_to_decimals : int, optional (default=2)
+        Exactly matched coordinates are rounded to the number of decimals given
+        here to avoid floating point errors.
+    non_matched_references : list of CalibrationReference, optional (default=None)
+        In case the possible range of coordinates in available observations is
+        outside the range of coordinates in the calibration database, additional
+        reference objects can be supplied to avoid inaccurate lookups. These
+        objects are only used to set the coordinate value minima and maxima used
+        in the nondimensionalisation and are not queried.
+    """
+    def __init__(
+            self,
+            calibration_reference_list,
+            closely_matched_coordinates,
+            exactly_matched_coordinates=None,
+            exactly_matched_round_to_decimals=2,
+            non_matched_references=None
+        ):
+        if len(calibration_reference_list) == 0:
+            raise ValueError('calibration_reference_list is an empty list.')
+
+        self.calibration_reference_list = calibration_reference_list
+        self.closely_matched_coordinates = closely_matched_coordinates
+        self.exactly_matched_round_to_decimals = exactly_matched_round_to_decimals
+        
+        if exactly_matched_coordinates is None:
+            self.exactly_matched_coordinates = []
+        else:
+            self.exactly_matched_coordinates = exactly_matched_coordinates
+
+        self.matched_coordinates = self.closely_matched_coordinates + self.exactly_matched_coordinates
+
+        self.closely_matched_coordinates_n = len(self.closely_matched_coordinates)
+        self.exactly_matched_coordinates_n = len(self.exactly_matched_coordinates)
+
+        coordinates_dimful_stacked = np.vstack([itemgetter(*self.matched_coordinates)(calibration_data.coordinates_dimful)
+                                                for calibration_data
+                                                in self.calibration_reference_list])
+        if non_matched_references is not None:
+            nm_coordinates_dimful_stacked = np.vstack([itemgetter(*self.matched_coordinates)(nm_data.coordinates_dimful)
+                                                    for nm_data
+                                                    in non_matched_references])
+
+        # Prepend an index column
+        coordinates_dimful_stacked = np.hstack(
+            (np.atleast_2d(np.array(range(0, len(self.calibration_reference_list)))).T,
+             coordinates_dimful_stacked)
+        )
+
+        # Determine the existing combinations of the exactly matched coordinates
+        if self.exactly_matched_coordinates_n > 0:
+            # Round the exactly matched coordinates to avoid floating point errors
+            coordinates_dimful_stacked[:, -(self.exactly_matched_coordinates_n):] = np.round(
+                coordinates_dimful_stacked[:, -(self.exactly_matched_coordinates_n):],
+                decimals=self.exactly_matched_round_to_decimals,
+            )
+
+            # Do the same for the non-matched references
+            if non_matched_references is not None:
+                nm_coordinates_dimful_stacked[:, -(self.exactly_matched_coordinates_n):] = np.round(
+                    nm_coordinates_dimful_stacked[:, -(self.exactly_matched_coordinates_n):],
+                    decimals=self.exactly_matched_round_to_decimals,
+                )
+
+            # Find the available unique combinations of the exactly matched coordinates
+            unique_exactly_matchables = [
+                tuple(row)
+                for row
+                in np.unique(coordinates_dimful_stacked[:, -(self.exactly_matched_coordinates_n):], axis=0)]
+        else:
+            unique_exactly_matchables = [tuple()]
+
+        # Build a database: dict indexed by the unique combinations of the exactly matchable coordinates
+        # This database is always recreated at runtime: this is not ideal, but
+        # for the current database size, it is fast enough. In the future, it could be serialized.
+        
+        self.database = {}
+
+        # Create the database entries for the unique combinations of the exactly matchable coordinates
+        for uem in unique_exactly_matchables:
+            # Are there even any exactly matchable coordinates?
+            if self.exactly_matched_coordinates_n > 0:
+                # Filter the original list to matches
+                reduced = coordinates_dimful_stacked[
+                    np.all(
+                        coordinates_dimful_stacked[:, -(self.exactly_matched_coordinates_n):] == uem,
+                        axis=1,
+                    )
+                ][:, :self.closely_matched_coordinates_n + 1]  # indices and all closely matched coords
+
+                # Do the same reduction for the non-matched references
+                if non_matched_references is not None:
+                    nm_reduced = nm_coordinates_dimful_stacked[
+                        np.all(
+                            nm_coordinates_dimful_stacked[:, -(self.exactly_matched_coordinates_n):] == uem,
+                            axis=1,
+                        )
+                    ][:, :self.closely_matched_coordinates_n]  # no index here, only closely matched coords
+
+            else:
+                reduced = coordinates_dimful_stacked
+                nm_reduced = nm_coordinates_dimful_stacked
+
+            index = np.asarray(reduced[:, 0], dtype='int')
+
+            # Drop the index column
+            reduced = reduced[:, 1:]
+
+            # Dimensionless, closely matched coordinates
+            
+            # Calculate scaling ranges
+            scale_min = reduced.min(axis=0)
+            scale_max = reduced.max(axis=0)
+
+            if non_matched_references is not None:
+                # Take the non-matched references into account as well (this is their only purpose)
+                scale_min = np.min([scale_min, np.min(nm_reduced, axis=0)], axis=0)
+                scale_max = np.max([scale_max, np.max(nm_reduced, axis=0)], axis=0)
+
+            # Filter coordinates where there is no actual range taken by the values
+            # to avoid division by 0 
+            indices_with_range = ~(scale_min == scale_max)
+
+            if np.sum(indices_with_range) == 0:
+                # No coordinates with range
+                if len(reduced) == 1:
+                    # No problem, only one reference, this we can match
+                    self.database[uem] = {
+                        'db_index_list' : list(index),
+                        'coordinates_with_range' : list(np.array(closely_matched_coordinates)[indices_with_range]),
+                        'scale_min' : None,
+                        'scale_max' : None,
+                        'kdtree_dimless' : None,
+                    }
+                else:
+                    # Otherwise, no match can be determined, since there are no
+                    # coordinates with any range among the reference values
+                    raise ValueError(f"The coordinates to be closely matched are all identical for the exactly matched combination {uem}, for reference instances with indices: {list(index)}.")
+            else:
+                coords_nontrivial_dimless = (reduced[:, indices_with_range] - scale_min[np.newaxis, indices_with_range]) / (scale_max[np.newaxis, indices_with_range] - scale_min[np.newaxis, indices_with_range])
+                print(f'{coords_nontrivial_dimless=}')
+                
+                kdtree_dimless = KDTree(coords_nontrivial_dimless)
+
+                self.database[uem] = {
+                    'db_index_list' : list(index),
+                    'coordinates_with_range' : list(np.array(closely_matched_coordinates)[indices_with_range]),
+                    'scale_min' : list(scale_min[indices_with_range]),
+                    'scale_max' : list(scale_max[indices_with_range]),
+                    'kdtree_dimless' : kdtree_dimless,
+                }
+
+    def find_nearest_match(self, query_calibration_data):
+        """Find the nearest match to a given CalibrationReference object in the
+        database.
+
+        Exactly matched coordinates must be identical to the coordinates of at
+        least one object in the database for nearest-neighbor lookup to be
+        performed.
+
+        Parameters
+        ----------
+        query_calibration_data : CalibrationReference
+            The object to find the closest match to.
+
+        Returns
+        -------
+        dist_scaled : float
+            Distance from the nearest neighbor scaled to the [0,1] range, where
+            0 is an exact match and 1 is the largest possible distance.
+        
+        original_index : int
+            The index of the query result in the original list provided during
+            the construction of the database.
+        
+        query_result : CalibrationReference
+            The best match to `query_calibration_data` in the database.
+        """
+        # First, check the coordinates to be matched exactly
+        if self.exactly_matched_coordinates_n > 0:
+            exactly_coords = tuple(query_calibration_data.coordinates_dimful[emc] for emc in self.exactly_matched_coordinates)
+        else:
+            exactly_coords = tuple()
+
+        if exactly_coords not in self.database:
+            raise ValueError(f"Coordinates {tuple(self.exactly_matched_coordinates)}={exactly_coords} could not be matched exactly in the current database.")
+            
+        # Then, find the nearest match among the instances where the other
+        # coordinates are matched exactly
+
+        # Get everything needed to perform the search
+        matched_db_entry = self.database[exactly_coords]
+
+        db_index_list = matched_db_entry['db_index_list']
+        kdtree_dimless = matched_db_entry['kdtree_dimless']
+
+        if kdtree_dimless is None:
+            # Only a single reference matches
+            if len(db_index_list) == 1:
+                return -1, db_index_list[0], self.calibration_reference_list[db_index_list[0]]
+            else:
+                raise RuntimeError("Cannot determine match: no K-d tree for exactly matched coordinates, but len(db_index_list) > 1")
+            
+        scale_min = np.array(matched_db_entry['scale_min'])
+        scale_max = np.array(matched_db_entry['scale_max'])
+        coordinates_with_range = matched_db_entry['coordinates_with_range']
+
+        # We only need the coordinates with range
+        query_reduced_only_range = np.array([query_calibration_data.coordinates_dimful[cwr] for cwr in coordinates_with_range])
+
+        # Scale it appropriately
+        query_coords_nontrivial_dimless = (query_reduced_only_range - scale_min) / (scale_max - scale_min)
+
+        print(f'{query_coords_nontrivial_dimless=}')
+
+        # Find the match
+        dist, nearest_i = kdtree_dimless.query(query_coords_nontrivial_dimless)
+
+        # Index in the original list
+        original_index = db_index_list[nearest_i]
+
+        # Scale the distance to between 0 and 1:
+        max_dist = np.sqrt(kdtree_dimless.m)
+        dist_scaled = dist / max_dist
+
+        return dist_scaled, original_index, self.calibration_reference_list[original_index]

--- a/intensity_calibration.py
+++ b/intensity_calibration.py
@@ -415,7 +415,6 @@ class CalibrationDatabase():
                     raise ValueError(f"The coordinates to be closely matched are all identical for the exactly matched combination {uem}, for reference instances with indices: {list(index)}.")
             else:
                 coords_nontrivial_dimless = (reduced[:, indices_with_range] - scale_min[np.newaxis, indices_with_range]) / (scale_max[np.newaxis, indices_with_range] - scale_min[np.newaxis, indices_with_range])
-                print(f'{coords_nontrivial_dimless=}')
                 
                 kdtree_dimless = KDTree(coords_nontrivial_dimless)
 
@@ -487,8 +486,6 @@ class CalibrationDatabase():
 
         # Scale it appropriately
         query_coords_nontrivial_dimless = (query_reduced_only_range - scale_min) / (scale_max - scale_min)
-
-        print(f'{query_coords_nontrivial_dimless=}')
 
         # Find the match
         dist, nearest_i = kdtree_dimless.query(query_coords_nontrivial_dimless)

--- a/intensity_calibration.py
+++ b/intensity_calibration.py
@@ -172,6 +172,10 @@ class CalibrationReference:
             shots_folder_bes = None
             
         if shots_folder_bes is not None:
+            # Do this to trigger downloading
+            d = flap.get_data('MAST_BES', shotnumber, 'BES-5-5')
+
+            # Filter temperature is not available in the DataObject.info
             nc_file = os.path.join(shots_folder_bes, shotstring, file_name_from_shot_number(shotnumber))
                                
             with h5py.File(nc_file) as f:

--- a/intensity_calibration.py
+++ b/intensity_calibration.py
@@ -250,7 +250,7 @@ class CalibrationReference:
             raise ValueError("Only method 'mean' is supported currently.")
 
         # Convert ndarray to list so it can be serialized later
-        self.calibration_multiplier_matrix = (np.max(cal_data.data) / cal_data.data).tolist()
+        self.calibration_multiplier_matrix = (1 / cal_data.data).tolist()
     
 class CalibrationDatabase():
     """Calibration database for storing CalibrationReference objects and finding

--- a/intensity_calibration.py
+++ b/intensity_calibration.py
@@ -173,7 +173,7 @@ class CalibrationReference:
             
         if shots_folder_bes is not None:
             # Do this to trigger downloading
-            d = flap.get_data('MAST_BES', shotnumber, 'BES-5-5')
+            _ = flap.get_data('MAST_BES', shotnumber, 'BES-5-5', options={'Calibrate intensity' : False})
 
             # Filter temperature is not available in the DataObject.info
             nc_file = os.path.join(shots_folder_bes, shotstring, file_name_from_shot_number(shotnumber))
@@ -393,7 +393,7 @@ class CalibrationDatabase():
             scale_min = reduced.min(axis=0)
             scale_max = reduced.max(axis=0)
 
-            if non_matched_references is not None:
+            if (non_matched_references is not None) and (len(nm_reduced) > 0):
                 # Take the non-matched references into account as well (this is their only purpose)
                 scale_min = np.min([scale_min, np.min(nm_reduced, axis=0)], axis=0)
                 scale_max = np.max([scale_max, np.max(nm_reduced, axis=0)], axis=0)

--- a/mast_bes.py
+++ b/mast_bes.py
@@ -753,7 +753,7 @@ def get_data_mast_bes(exp_id=None, data_name=None, no_data=False, options=None, 
             cref_chmap = np.array(calibration_cref.calibration_source['channel_map'])
             if np.all(chmap == cref_chmap):
                 # calibration multiplier matrix array
-                cmma = np.array(cref.calibration_multiplier_matrix)
+                cmma = np.array(calibration_cref.calibration_multiplier_matrix)
                 if outdim == 3:
                     if d.data.shape == (8,8):
                         d.data *= cmma

--- a/mast_bes.py
+++ b/mast_bes.py
@@ -78,6 +78,28 @@ def get_data_mast_bes(exp_id=None, data_name=None, no_data=False, options=None, 
             - If provided, the given path will be used as the cache directory.
             - If not provided, and 'Download' data is True, the data will be
               downloaded into memory but not cached.
+        'Calibrate amplitudes' (bool):
+            - False: Do not apply any calibration
+            - True: Apply calibration based on the given parameters.
+        'Calibration exact coordinates' (list of str, default=['APDCam_viewRadius']):
+            - Calibration coordinates that are to be matched exactly.
+        'Calibration nearby coordinates' (list of str, default=['APDCam_biasSet0', 'APDCam_biasSet1', 'filter_temperature_read', 'SS_voltage_99']):
+            - Calibration coordinates which will be used for selecting the
+              closest match between those reference measurements that fit the
+              exactly matced coordinates.
+        'Calibration file' (str):
+            - If given, this file is used as the reference measurement in the
+              calibration procedure, without any matching. Cannot be used
+              simultaneously with 'Calibration directory'.
+        'Calibration directory' (str):
+            - If given, the calibration reference files in this directory are used to
+              construct a database, and the best match is selected based on the
+              nearby and exactly matched coordinates given in the options.
+              Cannot be used simultaneously with 'Calibration file'.
+        'Calibration voltage reference' (float, default=1):
+            - Only values higher than the reference will be considered when
+              determining the 99th percentile voltage value that is considered as
+              the nominal beam voltage. Dimension: Volts.
         'Download data' (bool):
             - False: Do not download anything, only use data from 'Datapath'.
             - True: Download data from source specified in elements 'Server' and 'Server
@@ -114,6 +136,12 @@ def get_data_mast_bes(exp_id=None, data_name=None, no_data=False, options=None, 
     default_options = {'Datapath': 'data',
                        'Download data': False,
                        'Cache directory': None,
+                       'Calibrate amplitudes': False,
+                       'Calibration exact coordinates': ['APDCam_viewRadius'],
+                       'Calibration nearby coordinates': ['APDCam_biasSet0', 'APDCam_biasSet1', 'filter_temperature_read', 'SS_voltage_99'],
+                       'Calibration file': None,
+                       'Calibration directory' : None,
+                       'Calibration voltage reference': 1,
                        'Scaling':'Digit',
                        'Offset timerange': [-0.1,-0.01],
                        'Resample' : None,
@@ -142,6 +170,9 @@ def get_data_mast_bes(exp_id=None, data_name=None, no_data=False, options=None, 
         if not isinstance(datapath, str):
             raise ValueError(f"Invalid cache directory '{datapath}'.")
     
+    if (_options['Calibration directory'] is not None) and (_options['Calibration file'] is not None):
+        raise ValueError("Both of the options 'Calibration directory' and 'Calibration file' are set: these are mutually exclusive options, only one can be set.")
+
     def file_name_from_shot_number(shot_number, is_test_measurement=False):
         shotstring = str(shot_number).zfill(6)
         if not is_test_measurement:
@@ -642,6 +673,14 @@ def get_data_mast_bes(exp_id=None, data_name=None, no_data=False, options=None, 
     if _options['Remove sharp peaks']:
         print('Performing sharp peak removal...')
         d = d.remove_sharp_peaks()
+
+    if _options['Calibrate amplitudes']:
+        if _options['Calibration file'] is not None:
+            # TODO
+            raise NotImplementedError()
+        elif _options['Calibration directory'] is not None:
+            # TODO
+            raise NotImplementedError()
 
     return d
 

--- a/mast_bes.py
+++ b/mast_bes.py
@@ -740,7 +740,7 @@ def get_data_mast_bes(exp_id=None, data_name=None, no_data=False, options=None, 
             calibration_filename = valid_calibration_filenames[nearest_match_i]
             calibration_cref = nearest_match
             
-            print(f'Found match in database ({match_dist:0.02f}): {calibration_filename}')
+            print(f'Found match in database (distance: {match_dist:0.02f}): {calibration_filename}')
 
         elif _options['Calibration file'] is not None:
             calibration_filename = _options['Calibration file']

--- a/mast_bes.py
+++ b/mast_bes.py
@@ -12,6 +12,8 @@ import numpy as np
 import copy
 import h5py
 import psutil
+import itertools
+import warnings
 
 import flap
 from flap_apdcam.apdcam_control import apdcam_channel_map,apdcam10g_channel_map
@@ -79,7 +81,7 @@ def get_data_mast_bes(exp_id=None, data_name=None, no_data=False, options=None, 
             - If provided, the given path will be used as the cache directory.
             - If not provided, and 'Download' data is True, the data will be
               downloaded into memory but not cached.
-        'Calibrate amplitudes' (bool):
+        'Calibrate intensity' (bool):
             - False: Do not apply any calibration
             - True: Apply calibration based on the given parameters.
         'Calibration exact coordinates' (list of str, default=['APDCam_viewRadius']):
@@ -97,7 +99,7 @@ def get_data_mast_bes(exp_id=None, data_name=None, no_data=False, options=None, 
               construct a database, and the best match is selected based on the
               nearby and exactly matched coordinates given in the options.
               Cannot be used simultaneously with 'Calibration file'.
-        'Calibration voltage reference' (float, default=1):
+        'Calibration beam voltage reference' (float, default=1):
             - Only values higher than the reference will be considered when
               determining the 99th percentile voltage value that is considered as
               the nominal beam voltage. Dimension: Volts.
@@ -142,12 +144,12 @@ def get_data_mast_bes(exp_id=None, data_name=None, no_data=False, options=None, 
     default_options = {'Datapath': 'data',
                        'Download data': False,
                        'Cache directory': None,
-                       'Calibrate amplitudes': False,
+                       'Calibrate intensity': False,
                        'Calibration exact coordinates': ['APDCam_viewRadius'],
                        'Calibration nearby coordinates': ['APDCam_biasSet0', 'APDCam_biasSet1', 'filter_temperature_read', 'SS_voltage_99'],
                        'Calibration file': None,
                        'Calibration directory' : None,
-                       'Calibration voltage reference': 1,
+                       'Calibration beam voltage reference': 1,
                        'Scaling':'Digit',
                        'Offset timerange': [-0.1,-0.01],
                        'Resample' : None,
@@ -332,6 +334,7 @@ def get_data_mast_bes(exp_id=None, data_name=None, no_data=False, options=None, 
             raise ValueError(f"For camera type {camera_type} and serial {camera_info['genCameraSerial']}, no deployment channel numbering is available. Set the option 'Use deployment channel numbering' to False, or implement a deployment channel numbering in 'mast_bes.py' for this configuration.")
     ch_names = []
     adc_list = []
+    adc_rc_list = []
     row_list = []
     col_list = []
     nrow = chmap.shape[0]
@@ -346,6 +349,8 @@ def get_data_mast_bes(exp_id=None, data_name=None, no_data=False, options=None, 
             col_list.append(None)
             adc_list.append(chmap[ir,ic])
             adc_list.append(chmap[ir,ic])
+            adc_rc_list.append((ir,ic))
+            adc_rc_list.append((ir,ic))
     try:
         chname_proc, ch_index = flap.select_signals(ch_names,chspec)
     except ValueError as e:
@@ -355,6 +360,7 @@ def get_data_mast_bes(exp_id=None, data_name=None, no_data=False, options=None, 
     if (len(row_list) != 0):
         row_proc = [row_list[i] for i in ch_index]
     ADC_proc = [adc_list[i] for i in ch_index]
+    ADC_rc_proc = [adc_rc_list[i] for i in ch_index]
 
     # Determining the dimension of the output data array
     if (len(chname_proc) == 1):
@@ -687,18 +693,88 @@ def get_data_mast_bes(exp_id=None, data_name=None, no_data=False, options=None, 
         print('Performing sharp peak removal...')
         d = d.remove_sharp_peaks()
 
-    if _options['Calibrate amplitudes']:
-        if _options['Calibration file'] is not None:
-            # TODO
-            raise NotImplementedError()
-        elif _options['Calibration directory'] is not None:
-            # TODO
-            raise NotImplementedError()
+    if _options['Calibrate intensity']:
+        from .intensity_calibration import CalibrationReference, CalibrationDatabase
+        calibration_filename = None
+        calibration_cref = None
+        if _options['Calibration directory'] is not None:
+            calibration_dir = _options['Calibration directory']
+            print(f'Using intensity calibration directory {calibration_dir} to find proper match')
+
+            possible_calibration_filenames = [
+                os.path.join(calibration_dir, node)
+                for node
+                in os.listdir(calibration_dir)
+                if (os.path.isfile(os.path.join(calibration_dir, node)) and node.endswith('.json'))
+            ]
+
+            calibration_refs = []
+            valid_calibration_filenames = []
+            for fname in possible_calibration_filenames:
+                try:
+                    with open(fname, 'r') as f:
+                        cref = CalibrationReference.from_json(f.read())
+                        if cref.calibration_multiplier_matrix is None:
+                            warnings.warn(f"Unable to import calibration reference file {fname}. (No calibration multiplier matrix found.)")
+                        else:
+                            calibration_refs.append(cref)
+                            valid_calibration_filenames.append(fname)
+                except Exception as e:
+                    warnings.warn(f"Unable to import calibration reference file {fname}. ({e})")
+                    
+            actual_ref = CalibrationReference.from_MAST_U_shot(
+                exp_id,
+                beam_voltage_threshold_SI=_options['Calibration beam voltage reference'],
+            )
+
+            cdb = CalibrationDatabase(
+                calibration_refs,
+                exactly_matched_coordinates=_options['Calibration exact coordinates'],
+                closely_matched_coordinates=_options['Calibration nearby coordinates'],
+                exactly_matched_round_to_decimals=2,
+                non_matched_references=[actual_ref],
+            )
+
+            match_dist, nearest_match_i, nearest_match = cdb.find_nearest_match(actual_ref)
+
+            calibration_filename = valid_calibration_filenames[nearest_match_i]
+            calibration_cref = nearest_match
+            
+            print(f'Found match in database ({match_dist:0.02f}): {calibration_filename}')
+
+        elif _options['Calibration file'] is not None:
+            calibration_filename = _options['Calibration file']
+            with open(calibration_filename) as f:
+                calibration_cref = CalibrationReference.from_json(f.read())
+        else:
+            raise ValueError(f"Option 'Calibrate intensity' is True, but neither option 'Calibration file' nor option 'Calibration directory' are set.")
+
+        if (calibration_filename is not None) and (calibration_cref is not None):
+            cref_chmap = np.array(calibration_cref.calibration_source['channel_map'])
+            if np.all(chmap == cref_chmap):
+                # calibration multiplier matrix array
+                cmma = np.array(cref.calibration_multiplier_matrix)
+                if outdim == 3:
+                    if d.data.shape == (8,8):
+                        d.data *= cmma
+                    else:
+                        out_row_list_i = np.array(out_row_list) - 1
+                        out_col_list_i = np.array(out_col_list) - 1
+                        d.data *= cmma[np.ix_(out_row_list_i, out_col_list_i)]
+                elif outdim == 2:
+                    d.data *= cmma[*np.array(ADC_rc_proc).T]
+                    pass
+                elif outdim == 1:
+                    d.data *= cmma[*ADC_rc_proc[0]]
+                else:
+                    raise RuntimeError('This should never happen: outdim != 1, 2, or 3.')
+
+                d.data_unit.unit = 'n.a.'
+                print(f'Applied intensity calibration from {calibration_filename}')
+            else:
+                raise ValueError('Channel map in current data and reference calibration file do not match.')
 
     return d
-
-
-
 
 def register(data_source=None):
     flap.register_data_source('MAST_BES', get_data_func=get_data_mast_bes, add_coord_func=None)


### PR DESCRIPTION
This adds the possibility for automatic or manual intensity calibration of MAST-U BES data.

Calibration files are .json files that compensate for the differences between measurements from individual photodiodes, based on time-averages from a reference measurement. A new `CalibrationReference` class is added for proper calculation and handling of such data.

Based on several calibration files, for a given measurement, the most closely matching reference calibration file can be applied. The matching is based on calibration coordinates of the reference, which can either be exactly matched (these must be exactly the same in the given measurement and in the calibration reference), or closely matched (these can differ, but the difference should be minimized). This is implemented in the new `CalibrationDatabase` class. A collection of calibration files in a directory is treated as a calibration database.

Automatic calibration can be enabled by adding the following lines to the actual flap configuration:
```
[Module MAST_BES] 
 Calibrate intensity = True 
 Calibration directory = '/path/to/calibration/database/directory/' 
```

Manual calibration is also possible, by specifying a single file:
```
[Module MAST_BES] 
 Calibrate intensity = True 
 Calibration file = '/some/directory/calibration_file.json' 
```

Additional details regarding the calibration coordinates, matching etc. is contained in the docstrings.