### PR TITLE
Handle MU02 campaign shots

### DIFF
--- a/intensity_calibration.py
+++ b/intensity_calibration.py
@@ -1,5 +1,6 @@
 from operator import itemgetter
 import os
+import warnings
 
 import h5py
 import numpy as np
@@ -183,7 +184,11 @@ class CalibrationReference:
                     # This is an APDCam-10G
                     apdcam_viewRadius = f['devices']['d3_APDcamera10G'].attrs['viewRadius']
                     apdcam_biasSet = f['devices']['d3_APDcamera10G'].attrs['biasSet']
-                    filter_temperature_read = f['devices']['d8_filterheater'].attrs['temperature_read']
+                    if 'temperature_read' in f['devices']['d8_filterheater'].attrs:
+                        filter_temperature_read = f['devices']['d8_filterheater'].attrs['temperature_read']
+                    else:
+                        warnings.warn("'temperature_read' not available, using 'temperature_set' instead")
+                        filter_temperature_read = f['devices']['d8_filterheater'].attrs['temperature_set']
                 else:
                     raise NotImplementedError('Intensity calibration is only implemented for APDCam-10G')
         else:

--- a/mast_bes.py
+++ b/mast_bes.py
@@ -332,7 +332,11 @@ def get_data_mast_bes(exp_id=None, data_name=None, no_data=False, options=None, 
         else:
             raise ValueError(f'Unknown {camera_type=}')
 
-        time_vector = MAST_file['time1'][()]
+        try:
+            time_vector = MAST_file['time1'][()]
+        except KeyError:
+            time_vector = MAST_file['time'][()]
+
         camera_info['APDCAM_samplenumber'] = len(time_vector)
         camera_info['APDCAM_starttime'] = time_vector[0]
         camera_info['APDCAM_sampletime'] = (time_vector[-1] - time_vector[0]) / (len(time_vector - 1))


### PR DESCRIPTION
Handle MAST-U BES data where:
- the time coordinates have key 'time' instead of 'time1'
- 'temperature_read' is not available